### PR TITLE
mpapec-remove-flyouts-container

### DIFF
--- a/projects/ng-flyout/src/lib/ng-flyout.component.css
+++ b/projects/ng-flyout/src/lib/ng-flyout.component.css
@@ -13,7 +13,7 @@
 
     .backdrop {
         background-color: gray;
-        opacity: 0.8;
+        opacity: 0.4;
         cursor: pointer;
         width: 100%;
         height: 100%;
@@ -26,7 +26,7 @@
         position: absolute;
         top: 0;
         right: 0;
-
+        
         .header {
             height: 5%;
             display: flex;

--- a/projects/ng-flyout/src/lib/ng-flyout.service.ts
+++ b/projects/ng-flyout/src/lib/ng-flyout.service.ts
@@ -1,24 +1,33 @@
-import { Injectable, ViewContainerRef } from '@angular/core';
+import { ApplicationRef, createComponent, Inject, Injectable, Injector } from '@angular/core';
 import { NgFlyoutComponent } from './ng-flyout.component';
 import { Observable, skip } from 'rxjs';
 import { Flyout } from './models/flyout';
+import { DOCUMENT } from '@angular/common';
 
 @Injectable({
   providedIn: 'root'
 })
 export class NgFlyoutService {
-  private flyoutsContainerRef!: ViewContainerRef;
 
-  setFlyoutContainerRef(flyoutsContainerRef: ViewContainerRef) {
-    this.flyoutsContainerRef = flyoutsContainerRef;
-  }
+  constructor(
+    private applicationRef: ApplicationRef,
+    private injector: Injector,
+    @Inject(DOCUMENT) private document: Document
+  ) { }
 
   create<T>(flyoutData: Flyout<T>): Observable<T> {
-    let flyout = this.flyoutsContainerRef.createComponent(NgFlyoutComponent);
-    flyout.instance.flyoutData = flyoutData;
-    flyout.instance.destroy = () => flyout.destroy();
-    
-    return flyout.instance.componentBehaviorSubject.pipe(skip(1)); 
+    let flyoutComponentRef = createComponent(NgFlyoutComponent, {
+      environmentInjector: this.applicationRef.injector,
+      elementInjector: this.injector
+    });
+
+    this.applicationRef.attachView(flyoutComponentRef.hostView);
+    this.document.body.appendChild(flyoutComponentRef.location.nativeElement);
+
+    flyoutComponentRef.instance.flyoutData = flyoutData;
+    flyoutComponentRef.instance.destroy = () => flyoutComponentRef.destroy();
+
+    return flyoutComponentRef.instance.componentBehaviorSubject.pipe(skip(1));
     // pipe(skip(1)) is "hack" since first value that componentBehaviorSubject emits is one that is assigend on initialize
     // and that is null. Next value is ComponentRef of component we render as flyout content
   }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,3 +1,1 @@
 <button (click)="openFlyout()">Open Flyout</button>
-
-<div #flyouts></div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, ViewChild, ViewContainerRef } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { Flyout, HeaderButton, NgFlyoutService } from 'ng-flyout';
 import { FormComponent } from './form/form.component';
 
@@ -7,14 +7,12 @@ import { FormComponent } from './form/form.component';
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css']
 })
-export class AppComponent implements AfterViewInit{
+export class AppComponent implements OnInit{
   title = 'flyout';
-  @ViewChild("flyouts", { read: ViewContainerRef }) flyouts!: ViewContainerRef;
 
   constructor(public flyoutService: NgFlyoutService) { }
 
-  ngAfterViewInit(): void {
-    this.flyoutService.setFlyoutContainerRef(this.flyouts);
+  ngOnInit(): void {
     this.openFlyout();
   }
   


### PR DESCRIPTION
use body html element as flyouts container so that user does not have to manually add flyouts container and pass its ViewComponentRef to service